### PR TITLE
Replace 'Contants' with 'Constants'

### DIFF
--- a/src/main/resources/assets/nodeflow/lang/en_us.json
+++ b/src/main/resources/assets/nodeflow/lang/en_us.json
@@ -105,7 +105,7 @@
   "group.nodeflow.debug": "Debug",
   "group.nodeflow.advanced_math": "Advanced Math",
   "group.nodeflow.compare_number": "Compare Number",
-  "group.nodeflow.constants": "Contants",
+  "group.nodeflow.constants": "Constants",
 
   "key.nodeflow.debug": "Open node debug screen",
   "key.categories.nodeflow": "Nodeflow"


### PR DESCRIPTION
Closes #1.

This pull request replaces the word "Contants" in lang/en_us.json with "Constants" to fix a typo.